### PR TITLE
Fix storage reset on extension update

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,7 @@
-chrome.runtime.onInstalled.addListener(() => {
-  chrome.storage.local.set({ urns: [] });
+chrome.runtime.onInstalled.addListener(details => {
+  if (details.reason === 'install') {
+    chrome.storage.local.set({ urns: [] });
+  }
 });
 chrome.webNavigation.onHistoryStateUpdated.addListener(details => {
   if (!details.url.includes('/in/')) return;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "pickedin",
   "version": "1.0.0",
   "scripts": {
-    "test": "echo \"No tests defined\" && exit 0"
+    "test": "node test/onInstalled.test.js"
   }
 }

--- a/test/onInstalled.test.js
+++ b/test/onInstalled.test.js
@@ -1,0 +1,26 @@
+const assert = require('assert');
+
+let listener;
+const setCalls = [];
+
+// minimal chrome mock
+global.chrome = {
+  runtime: { onInstalled: { addListener: fn => { listener = fn; } } },
+  storage: { local: { set: obj => setCalls.push(obj) } },
+  webNavigation: { onHistoryStateUpdated: { addListener: () => {} } },
+  scripting: { executeScript: () => {} }
+};
+
+// load background.js which registers the listener
+require('../background.js');
+
+// simulate install
+listener({ reason: 'install' });
+assert.deepStrictEqual(setCalls, [{ urns: [] }], 'install should reset list');
+
+// reset calls and simulate update
+setCalls.length = 0;
+listener({ reason: 'update' });
+assert.deepStrictEqual(setCalls, [], 'update should not reset list');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- only reset the `urns` array on fresh install
- add a basic test for the runtime listener
- run the test via npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856e9db11f883278bb46db02c2ed5f1