### PR TITLE
Version 1.22 with per‑profile links

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -6,6 +6,7 @@ PickedIn est une extension Chrome permettant d'enregistrer les URN de profils Li
 - Bouton flottant « pIn » sur les pages LinkedIn pour ouvrir le panneau.
 - **Ajouter un profil :** enregistre le profil courant (jusqu'à 50 éléments).
 - **Voir les articles :** ouvre une recherche LinkedIn pour afficher les publications des profils enregistrés.
+- Un bouton-lien à côté de chaque profil ouvre ses articles individuellement.
 - **Importer/Exporter :** sauvegarde ou restauration de la liste au format JSON.
 - Page d'options pour renseigner la clé API et l'identifiant de base Airtable.
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This Chrome extension helps you save LinkedIn profile URNs so you can quickly vi
 - Floating "pIn" button on LinkedIn pages to open the panel.
 - **Add profile:** save the current profile (up to 50 entries).
 - **View posts:** open a LinkedIn search for the saved profiles' posts.
+- A link button next to each saved profile opens posts for that profile only.
 - **Import/Export:** backup or restore your saved list as JSON.
 - Options page to store an Airtable API key and base ID.
 

--- a/content-script.js
+++ b/content-script.js
@@ -59,9 +59,15 @@
     list.forEach((p, i) => {
       const div = document.createElement('div'); div.className='myl_item';
       const span = document.createElement('span'); span.textContent=`${i+1}. ${p.name||p.urn}`;
+      const link = document.createElement('button'); link.className='posts_btn';
+      link.textContent='🔗'; link.title='Voir les articles';
+      link.onclick = () => {
+        const id=p.urn.replace(/^urn:li:fs_profile:/,'');
+        window.open(`https://www.linkedin.com/search/results/content/?fromMember=%5B%22${id}%22%5D&origin=FACETED_SEARCH&sortBy=%22date_posted%22`,'_blank');
+      };
       const del = document.createElement('button'); del.className='delete_btn'; del.textContent='×';
       del.onclick = async () => { const arr=(await getProfiles()).filter(x=>x.urn!==p.urn); await saveProfiles(arr); render(); };
-      div.append(span, del); container.appendChild(div);
+      div.append(span, link, del); container.appendChild(div);
     });
   };
 

--- a/content-style.css
+++ b/content-style.css
@@ -45,6 +45,7 @@
 #myl_list { flex: 1; overflow-y: auto; border: 1px solid #ddd; padding: 5px; border-radius: 4px; margin-bottom: 10px; }
 .myl_item { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 14px; }
 .delete_btn { background: transparent; border: none; color: #e03e2d; font-size: 18px; cursor: pointer; }
+.posts_btn { background: transparent; border: none; color: #2d64bc; font-size: 16px; cursor: pointer; margin-left: 4px; }
 /* Import/Export */
 #import_export { display: flex; gap: 5px; margin-top: auto; }
 #import_btn, #export_btn { flex: 1; padding: 8px; font-size: 14px; background: #2d64bc; color: #fff; border: none; border-radius: 4px; }

--- a/manifest.json
+++ b/manifest.json
@@ -1,8 +1,8 @@
 {
   "manifest_version": 3,
   "name": "LinkedIn Profile Saver",
-  "version": "1.21",
-  "description": "v1.21: fix header size, prevent text selection on drag",
+  "version": "1.22",
+  "description": "v1.22: individual posts links",
   "permissions": ["storage","tabs","scripting","webNavigation","downloads"],
   "host_permissions": ["https://www.linkedin.com/*"],
   "background": { "service_worker": "background.js" },


### PR DESCRIPTION
## Summary
- bump extension version to 1.22
- add per-profile posts link and style
- document new button in README files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856f31c12448327ae52c3e5bc080cbb